### PR TITLE
fix(fancy_lsp_servers): cleaner way of fetching null-ls sources

### DIFF
--- a/lua/lualine/components/fancy_lsp_servers.lua
+++ b/lua/lualine/components/fancy_lsp_servers.lua
@@ -13,11 +13,10 @@ function M:update_status()
     for _, client in pairs(buf_clients) do
         if client.name == "null-ls" then
             if null_ls_installed then
-                for _, kind in ipairs({ "formatting", "diagnostics" }) do
-                    for tool, tool_config in pairs(null_ls.builtins[kind]) do
-                        if vim.tbl_contains(tool_config.filetypes, vim.bo.filetype) then
-                            table.insert(buf_client_names, tool)
-                        end
+                local m = null_ls.methods
+                for _, kind in ipairs({ m.FORMATTING, m.DIAGNOSTICS }) do
+                    for _, source in ipairs(null_ls.get_source({ filetype = vim.bo.filetype, method = kind })) do
+                        table.insert(buf_client_names, source.name)
                     end
                 end
             end

--- a/lua/lualine/components/fancy_lsp_servers.lua
+++ b/lua/lualine/components/fancy_lsp_servers.lua
@@ -13,11 +13,8 @@ function M:update_status()
     for _, client in pairs(buf_clients) do
         if client.name == "null-ls" then
             if null_ls_installed then
-                local m = null_ls.methods
-                for _, kind in ipairs({ m.FORMATTING, m.DIAGNOSTICS }) do
-                    for _, source in ipairs(null_ls.get_source({ filetype = vim.bo.filetype, method = kind })) do
-                        table.insert(buf_client_names, source.name)
-                    end
+                for _, source in ipairs(null_ls.get_source({ filetype = vim.bo.filetype })) do
+                    table.insert(buf_client_names, source.name)
                 end
             end
         else


### PR DESCRIPTION
Thank you for the amazing plugin!

## Bug

According to null-ls docs, the official way of fetching null-ls sources is to use the `get_source(query)` function instead of directly accessing `builtins` table.

https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/SOURCES.md

The biggest difference is that the current method does not distinguish sources that are disabled while results that return from `get_source` are already filtered internally.

## Fix

This PR uses `get_source` function with query of filetype instead.

One breaking change is that the previous code only listed sources of `formatting` and `diagnostics` but now it lists all sources (i.e. from `code_actions`, `completion`, `hover` as well)

Is there any reason you were filtering?

## Note

Out of the scope of this PR but I just wanted to inform you that `vim.lsp.buf_get_clients(bufnr)` has been deprecated since `nvim-0.9.0` to be replaced by `vim.lsp.get_active_clients({ bufnr = bufnr })`. [Ref](https://github.com/neovim/neovim/pull/18507#issuecomment-1128211203)

I'll leave it to you whether to fix it or not.