### PR TITLE
fix(fancy_cwd): substitute_home only if cwd starts with HOME

### DIFF
--- a/lua/lualine/components/fancy_cwd.lua
+++ b/lua/lualine/components/fancy_cwd.lua
@@ -11,7 +11,10 @@ end
 function M:update_status()
     local result = vim.fn.getcwd()
     if self.options.substitute_home then
-        result = result:gsub(os.getenv("HOME"), "~")
+        local home = os.getenv("HOME")
+        if home and vim.startswith(result, home) then
+            result = "~" .. result:sub(home:len() + 1)
+        end
     end
     return result
 end


### PR DESCRIPTION
Hi again.

I use a shared server where there is a shared harddisk mounted at `/storage` and we use it with a file structure of `/storage/home/username`.

This contains `$HOME` (`/home/username`) but I do not think it should be substituted with `~`. (It becomes `/storage~`.

This PR is a quick fix to substitute cwd only if it starts with `$HOME`.