### PR TITLE
`chore` : remove deprecated options

### DIFF
--- a/lua/lualine/components/fancy_location.lua
+++ b/lua/lualine/components/fancy_location.lua
@@ -1,14 +1,14 @@
 local M = require("lualine.component"):extend()
 
 function M:init(options)
-    options.icon = options.icon or { "󰍒", color = { fg = "#fc5603" }, align = "right" }
-    M.super.init(self, options)
+	options.icon = options.icon or { "󰍒", color = { fg = "#fc5603" }, align = "left" }
+	M.super.init(self, options)
 end
 
 function M:update_status()
-    local line = vim.fn.line(".")
-    local col = vim.fn.virtcol(".")
-    return string.format('%d:%d', line, col)
+	local line = vim.fn.line(".")
+	local col = vim.fn.virtcol(".")
+	return string.format("%d:%d", line, col)
 end
 
 return M

--- a/lua/lualine/components/fancy_lsp_servers.lua
+++ b/lua/lualine/components/fancy_lsp_servers.lua
@@ -1,7 +1,7 @@
 local M = require("lualine.component"):extend()
 
 function M:init(options)
-	options.icon = options.icon or " "
+	options.icon = options.icon or ""
 	options.split = options.split or ","
 	M.super.init(self, options)
 end

--- a/lua/lualine/components/fancy_lsp_servers.lua
+++ b/lua/lualine/components/fancy_lsp_servers.lua
@@ -1,33 +1,33 @@
-local M = require('lualine.component'):extend()
+local M = require("lualine.component"):extend()
 
 function M:init(options)
-    options.icon = options.icon or "󰌘"
-    options.split = options.split or ","
-    M.super.init(self, options)
+	options.icon = options.icon or "󰌘"
+	options.split = options.split or ","
+	M.super.init(self, options)
 end
 
 function M:update_status()
-    local buf_clients = nil
-    if vim.lsp.get_clients != nil then
-        -- buf_get_client is deprecated in nvim >=0.10.0
-        buf_clients = vim.lsp.get_clients({ bufnr = 0 })
-    else
-        buf_clients = vim.lsp.buf_get_clients()
-    end
-    local null_ls_installed, null_ls = pcall(require, "null-ls")
-    local buf_client_names = {}
-    for _, client in pairs(buf_clients) do
-        if client.name == "null-ls" then
-            if null_ls_installed then
-                for _, source in ipairs(null_ls.get_source({ filetype = vim.bo.filetype })) do
-                    table.insert(buf_client_names, source.name)
-                end
-            end
-        else
-            table.insert(buf_client_names, client.name)
-        end
-    end
-    return table.concat(buf_client_names, self.options.split)
+	local buf_clients = nil
+	if vim.lsp.get_clients ~= nil then
+		-- buf_get_client is deprecated in nvim >=0.10.0
+		buf_clients = vim.lsp.get_clients({ bufnr = 0 })
+	else
+		buf_clients = vim.lsp.get_clients()
+	end
+	local null_ls_installed, null_ls = pcall(require, "conform")
+	local buf_client_names = {}
+	for _, client in pairs(buf_clients) do
+		if client.name == "conform" then
+			if null_ls_installed then
+				for _, source in ipairs(null_ls.get_source({ filetype = vim.bo.filetype })) do
+					table.insert(buf_client_names, source.name)
+				end
+			end
+		else
+			table.insert(buf_client_names, client.name)
+		end
+	end
+	return table.concat(buf_client_names, self.options.split)
 end
 
 return M

--- a/lua/lualine/components/fancy_lsp_servers.lua
+++ b/lua/lualine/components/fancy_lsp_servers.lua
@@ -1,7 +1,7 @@
 local M = require("lualine.component"):extend()
 
 function M:init(options)
-	options.icon = options.icon or "󰌘"
+	options.icon = options.icon or " "
 	options.split = options.split or ","
 	M.super.init(self, options)
 end


### PR DESCRIPTION
vim.lsp.buf_get_client is deprecated, which didn't show lsp in statusline, after changing it, the lsp is shown again in statusline 